### PR TITLE
Fix placeholder replacement in X post generator

### DIFF
--- a/src/lib/xPostGenerator.ts
+++ b/src/lib/xPostGenerator.ts
@@ -46,7 +46,9 @@ export function generateXPost(category: string, variables: Record<string, string
   // Replace variables in the template
   let post = template.template;
   for (const [key, value] of Object.entries(variables)) {
-    post = post.replace(`{${key}}`, value);
+    // Replace all instances of the placeholder, not just the first
+    const pattern = new RegExp(`\\{${key}\\}`, 'g');
+    post = post.replace(pattern, value);
   }
 
   // Ensure the post is within X's character limit (280 characters)


### PR DESCRIPTION
## Summary
- replace all placeholder occurrences when generating X posts

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_6896bf2f9dac83249e494e3271ef1c0f