### PR TITLE
Require auth token for subscription operations

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -330,7 +330,12 @@ export default function Dashboard() {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to upgrade your plan.');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to start checkout process');
     }
   };
@@ -712,6 +717,11 @@ export default function Dashboard() {
                     const url = await createCustomerPortalSession();
                     window.location.href = url;
                   } catch (error: any) {
+                    if (error.message === 'Authentication required') {
+                      toast.error('Please log in to manage billing.');
+                      router.push('/login');
+                      return;
+                    }
                     const errorMessage = error.message || 'Failed to open billing portal';
                     toast.error(errorMessage);
                   }

--- a/src/app/debug-subscription/page.tsx
+++ b/src/app/debug-subscription/page.tsx
@@ -2,17 +2,24 @@
 
 import { useSubscription } from '@/context/SubscriptionContext';
 import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 export default function DebugSubscription() {
   const { user } = useAuth();
   const { subscription, syncSubscription, refreshSubscription, loading } = useSubscription();
+  const router = useRouter();
 
   const handleSync = async () => {
     try {
       await syncSubscription();
       toast.success('Subscription synced successfully!');
     } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to sync subscription');
+        router.push('/login');
+        return;
+      }
       toast.error(error.message || 'Failed to sync subscription');
     }
   };
@@ -22,6 +29,11 @@ export default function DebugSubscription() {
       await refreshSubscription();
       toast.success('Subscription refreshed!');
     } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to refresh subscription');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to refresh subscription');
     }
   };

--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -331,18 +331,23 @@ export default function ContentGenerator() {
       setSelectedHook(null);
       setThreadHooks([]);
       setShowHookSelection(false);
-    } catch (error) {
-      console.error('Error generating content:', error);
-      
-      let errorMessage = 'Failed to generate content. Please try again.';
-      
-      if (error instanceof Error) {
-        console.error('Error message:', error.message);
-        console.error('Error stack:', error.stack);
-        errorMessage = `Error: ${error.message}`;
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to generate content.');
+        router.push('/login');
+      } else {
+        console.error('Error generating content:', error);
+
+        let errorMessage = 'Failed to generate content. Please try again.';
+
+        if (error instanceof Error) {
+          console.error('Error message:', error.message);
+          console.error('Error stack:', error.stack);
+          errorMessage = `Error: ${error.message}`;
+        }
+
+        toast.error(errorMessage);
       }
-      
-      toast.error(errorMessage);
     } finally {
       setLoading(false);
     }
@@ -405,8 +410,13 @@ export default function ContentGenerator() {
       // Refresh subscription usage after generation
       await refreshSubscription();
       toast.success('Content generated successfully!');
-    } catch (error) {
-      toast.error('Failed to generate thread.');
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to generate content.');
+        router.push('/login');
+      } else {
+        toast.error('Failed to generate thread.');
+      }
     } finally {
       setLoading(false);
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,14 @@ import Link from 'next/link';
 import Layout from '@/components/layout/Layout';
 import { useSubscription } from '@/context/SubscriptionContext';
 import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
 import { Edit as FiEdit, Trophy as FiTrophy, Users as FiUsers, TrendingUp as FiTrendingUp, Check as FiCheck } from 'lucide-react';
 import toast from 'react-hot-toast';
 
 export default function Home() {
   const { subscription, createCheckoutSession } = useSubscription();
   const { user } = useAuth();
+  const router = useRouter();
   const [isLoading, setIsLoading] = useState<string | null>(null);
 
   const handleSubscribe = async (tier: 'STANDARD' | 'PREMIUM') => {
@@ -24,9 +26,14 @@ export default function Home() {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
-      console.error('Subscription error:', error);
-      toast.error('Failed to start checkout process');
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to subscribe to a plan');
+        router.push('/login');
+      } else {
+        console.error('Subscription error:', error);
+        toast.error('Failed to start checkout process');
+      }
     } finally {
       setIsLoading(null);
     }

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import Layout from '@/components/layout/Layout';
 import { useSubscription } from '@/context/SubscriptionContext';
 import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
 import { FiCheck, FiX, FiStar, FiZap, FiShield, FiHeadphones } from '@/lib/react-icons-compat';
 import toast from 'react-hot-toast';
 
@@ -13,6 +14,7 @@ export default function PricingPage() {
   const { subscription, createCheckoutSession } = useSubscription();
   const { user } = useAuth();
   const [isLoading, setIsLoading] = useState<string | null>(null);
+  const router = useRouter();
 
   const handleSubscribe = async (tier: 'STANDARD' | 'PREMIUM') => {
     if (!user) {
@@ -24,9 +26,14 @@ export default function PricingPage() {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
-      console.error('Subscription error:', error);
-      toast.error('Failed to start checkout process');
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to subscribe to a plan');
+        router.push('/login');
+      } else {
+        console.error('Subscription error:', error);
+        toast.error('Failed to start checkout process');
+      }
     } finally {
       setIsLoading(null);
     }

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -339,7 +339,12 @@ export default function ProjectPage({ params }: { params: { id: string } }) {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to upgrade your plan.');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to start checkout process');
     }
   };

--- a/src/components/subscription/BillingPortalButton.tsx
+++ b/src/components/subscription/BillingPortalButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSubscription } from '@/context/SubscriptionContext';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 interface BillingPortalButtonProps {
@@ -12,6 +13,7 @@ const BillingPortalButton: React.FC<BillingPortalButtonProps> = ({
   children = 'Manage Billing' 
 }) => {
   const { subscription, createCustomerPortalSession } = useSubscription();
+  const router = useRouter();
 
   const handleClick = async () => {
     // Check if user has a paid subscription
@@ -30,6 +32,11 @@ const BillingPortalButton: React.FC<BillingPortalButtonProps> = ({
       const url = await createCustomerPortalSession();
       window.location.href = url;
     } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to manage billing.');
+        router.push('/login');
+        return;
+      }
       const errorMessage = error.message || 'Failed to open billing portal';
       toast.error(errorMessage);
     }

--- a/src/components/subscription/SubscriptionDashboard.tsx
+++ b/src/components/subscription/SubscriptionDashboard.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { useSubscription } from '@/context/SubscriptionContext';
 import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 const SubscriptionDashboard: React.FC = () => {
   const { user } = useAuth();
+  const router = useRouter();
   const {
     subscription,
     tierDetails,
@@ -19,7 +21,12 @@ const SubscriptionDashboard: React.FC = () => {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to upgrade your plan.');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to start checkout process');
     }
   };
@@ -29,6 +36,11 @@ const SubscriptionDashboard: React.FC = () => {
       const url = await createCustomerPortalSession();
       window.location.href = url;
     } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to manage billing.');
+        router.push('/login');
+        return;
+      }
       const errorMessage = error.message || 'Failed to open billing portal';
       toast.error(errorMessage);
     }

--- a/src/components/subscription/SubscriptionStatusCard.tsx
+++ b/src/components/subscription/SubscriptionStatusCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useSubscription } from '@/context/SubscriptionContext';
 import { useAuth } from '@/context/AuthContext';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 import {
   CreditCard as FiCreditCard,
@@ -33,6 +34,7 @@ const SubscriptionStatusCard: React.FC<SubscriptionStatusCardProps> = ({
   showUsageHistory = true
 }) => {
   const { user } = useAuth();
+  const router = useRouter();
   const {
     subscription,
     tierDetails,
@@ -55,7 +57,12 @@ const SubscriptionStatusCard: React.FC<SubscriptionStatusCardProps> = ({
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to upgrade your plan.');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to start checkout process');
     }
   };
@@ -65,6 +72,11 @@ const SubscriptionStatusCard: React.FC<SubscriptionStatusCardProps> = ({
       const url = await createCustomerPortalSession();
       window.location.href = url;
     } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to manage billing.');
+        router.push('/login');
+        return;
+      }
       const errorMessage = error.message || 'Failed to open billing portal';
       toast.error(errorMessage);
     }

--- a/src/components/subscription/UsageWarning.tsx
+++ b/src/components/subscription/UsageWarning.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSubscription } from '@/context/SubscriptionContext';
+import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
 
 interface UsageWarningProps {
@@ -14,12 +15,18 @@ const UsageWarning: React.FC<UsageWarningProps> = ({ className = '' }) => {
     warning,
     createCheckoutSession,
   } = useSubscription();
+  const router = useRouter();
 
   const handleUpgrade = async (tier: 'STANDARD' | 'PREMIUM') => {
     try {
       const url = await createCheckoutSession(tier);
       window.location.href = url;
-    } catch (error) {
+    } catch (error: any) {
+      if (error.message === 'Authentication required') {
+        toast.error('Please log in to upgrade your plan.');
+        router.push('/login');
+        return;
+      }
       toast.error('Failed to start checkout process');
     }
   };


### PR DESCRIPTION
## Summary
- throw explicit error when auth token is missing in subscription context
- redirect users to log in when subscription actions are attempted without authentication

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `node - <<'NODE'
(async () => {
  try {
    const { data: { session } } = { data: { session: null } };
    if (!session?.access_token) throw new Error('Authentication required');
  } catch (e) {
    console.error(e.message);
  }
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_6896c328abf08324b85918ea8fb3b799